### PR TITLE
Adding Husky as a Git hook manager.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,13 @@
 {
-  "extends": "./node_modules/gts/"
+  "extends": "./node_modules/gts/",
+  "overrides": [
+    {
+      "files": [
+        "**/*.test.ts"
+      ],
+      "rules": {
+        "node/no-unpublished-import": 0
+      }
+    }
+  ]
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run fix
+npm test

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ This repo contains the code for the lessons from the "Learning 3D Graphics on th
 Make sure you have a Node version manager installed, [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) can do the trick.
 
 ## Prepare your local
-1. Clone the repo to your local, run git clone https://github.com/diegognt/threejs-basic
+1. Clone the repo to your local, run `git clone https://github.com/diegognt/threejs-basic`
 2. Get into the folder.
-3. Make sure you have the right Node version, use your Node version manager, please check the .nvmrc file.
-4. Install the necessary packages, run npm Install
-5. Start a local server, run npm run dev
-6. In your browser got to https://localhost:3000.
+3. Make sure you have the right Node version, use your Node version manager, please check the `.nvmrc` file.
+4. Install the necessary packages, run `npm i`
+5. Start a local server, run `npm run dev`
 
 Have fun.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^14.11.2",
         "@types/three": "^0.141.0",
         "gts": "^3.1.0",
+        "husky": "^8.0.0",
         "typescript": "^4.7.3",
         "vite": "^2.9.9",
         "vitest": "^0.17.1"
@@ -2242,6 +2243,21 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -5799,6 +5815,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "clean": "gts clean",
     "compile": "tsc",
     "fix": "gts fix",
-    "test": "vitest",
+    "test": "vitest --run",
     "coverage": "vitest run --coverage",
-    "prepare": "npm run compile",
+    "prepare": "npm run compile && husky install",
     "pretest": "npm run compile",
     "posttest": "npm run lint"
   },
@@ -23,7 +23,8 @@
     "gts": "^3.1.0",
     "typescript": "^4.7.3",
     "vite": "^2.9.9",
-    "vitest": "^0.17.1"
+    "vitest": "^0.17.1",
+    "husky": "^8.0.0"
   },
   "dependencies": {
     "dat.gui": "^0.7.9",


### PR DESCRIPTION
This PR includes:
   - Updates to add the correct format for CLI commands
   - Adding an override to the `.eslintrc` about using not publish packages on `*.test.ts` files
   - Adding `npm test` and formatting as pre-commit hook